### PR TITLE
fix: update id packet value in authentication guide

### DIFF
--- a/protocol-authenticating.md
+++ b/protocol-authenticating.md
@@ -12,7 +12,7 @@ The ID packet puts the Bluetooth device into a state where it's expecting an aut
 ```dart
 // Note that this is a status packet, so no header or CRC is expected
 
-List<int> idPacket() => [ 0x3A ];
+List<int> idPacket() => [ 0xEA ];
 ```
 
 ## Authentication Token Packet


### PR DESCRIPTION
Thanks for putting this guide together! I'm working my way through it to connect to my water softener.

I noticed a typo in the Authenticating protocol docs and have fixed it here. 